### PR TITLE
Refactor navigation to support section links outside nav menu

### DIFF
--- a/blog/js/main.js
+++ b/blog/js/main.js
@@ -117,25 +117,46 @@ document.addEventListener('DOMContentLoaded', () => {
     const navLinks = document.querySelectorAll('.nav-link');
     const sections = document.querySelectorAll('.section');
 
+    function navigateToSection(targetId) {
+        // Update active nav link
+        navLinks.forEach(l => {
+            if (l.getAttribute('href') === '#' + targetId) {
+                l.classList.add('active');
+            } else {
+                l.classList.remove('active');
+            }
+        });
+
+        // Show corresponding section
+        sections.forEach(section => {
+            if (section.id === targetId) {
+                section.classList.add('active');
+            } else {
+                section.classList.remove('active');
+            }
+        });
+    }
+
     navLinks.forEach(link => {
         link.addEventListener('click', (e) => {
             const href = link.getAttribute('href');
             if (href && href.startsWith('#')) {
                 e.preventDefault();
+                navigateToSection(href.slice(1));
+            }
+        });
+    });
 
-                // Update active nav link
-                navLinks.forEach(l => l.classList.remove('active'));
-                link.classList.add('active');
-
-                // Show corresponding section
-                const targetId = href.slice(1);
-                sections.forEach(section => {
-                    if (section.id === targetId) {
-                        section.classList.add('active');
-                    } else {
-                        section.classList.remove('active');
-                    }
-                });
+    // Handle section links outside the nav (banner "Learn more", hero buttons, etc.)
+    document.querySelectorAll('a[href^="#"]:not(.nav-link)').forEach(link => {
+        link.addEventListener('click', (e) => {
+            const href = link.getAttribute('href');
+            const targetId = href.slice(1);
+            const targetSection = document.getElementById(targetId);
+            if (targetSection && targetSection.classList.contains('section')) {
+                e.preventDefault();
+                navigateToSection(targetId);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
             }
         });
     });


### PR DESCRIPTION
## Description

This PR refactors the navigation logic to extract the section navigation functionality into a reusable `navigateToSection()` function and extends support for section links beyond the main navigation menu.

Previously, only navigation menu links could trigger section changes. Now, any anchor link pointing to a section (e.g., "Learn more" buttons in banners, hero buttons) will properly navigate to and display the target section with smooth scrolling.

The changes maintain backward compatibility while improving code reusability and reducing duplication.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [x] Refactor (no functional changes)
- [ ] Test improvement

## Changes Made

- Extracted navigation logic into a `navigateToSection(targetId)` function
- Updated nav link click handler to use the new function
- Added support for section links outside the navigation menu (`.nav-link` excluded)
- Added smooth scroll behavior when navigating via non-nav links
- Added validation to ensure target is a valid section element

## Checklist

- [x] Shell scripts pass syntax validation (N/A - JavaScript only)
- [x] All existing tests pass (no test files affected)
- [x] No emojis in code, comments, documentation, or commit messages
- [x] Code follows existing patterns and style conventions

## Test Plan

Verify that:
1. Navigation menu links continue to work as before
2. External section links (e.g., banner "Learn more" buttons) now properly navigate to sections
3. Smooth scrolling occurs when using non-nav section links
4. Invalid anchor links are ignored

https://claude.ai/code/session_018H7Rymx8ficp7y8HEPDfFF