### PR TITLE
fix: critical CLI fixes (#56, #58, #82)

### DIFF
--- a/autonomy/loki
+++ b/autonomy/loki
@@ -551,6 +551,10 @@ cmd_start() {
                 ;;
             --provider)
                 if [[ -n "${2:-}" ]]; then
+                    if [[ "$2" == --* ]]; then
+                        echo -e "${RED}Missing value for --provider flag${NC}"
+                        exit 1
+                    fi
                     provider="$2"
                     args+=("--provider" "$provider")
                     shift 2
@@ -10269,10 +10273,25 @@ cmd_worktree() {
                 return 1
             fi
 
+            # Validate JSON is parseable and contains required fields
+            if ! python3 -c "
+import json, sys
+try:
+    data = json.load(open('$signal_file'))
+    assert data.get('branch'), 'missing branch'
+    assert data.get('worktree'), 'missing worktree'
+except Exception as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(1)
+" 2>/dev/null; then
+                echo -e "${RED}Invalid or corrupted merge signal file${NC}"
+                exit 1
+            fi
+
             local branch
-            branch=$(python3 -c "import json; print(json.load(open('$signal_file'))['branch'])" 2>/dev/null)
+            branch=$(python3 -c "import json; print(json.load(open('$signal_file'))['branch'])")
             local worktree_path
-            worktree_path=$(python3 -c "import json; print(json.load(open('$signal_file'))['worktree'])" 2>/dev/null)
+            worktree_path=$(python3 -c "import json; print(json.load(open('$signal_file'))['worktree'])")
 
             if git merge --no-ff "$branch" -m "merge($name): auto-merge from parallel worktree"; then
                 echo -e "${GREEN}Merge successful${NC}"

--- a/autonomy/run.sh
+++ b/autonomy/run.sh
@@ -9194,8 +9194,9 @@ check_human_intervention() {
                 log_warn "PAUSE file created by budget limit - NOT auto-clearing in perpetual mode"
                 log_warn "Budget limit reached. Remove .loki/signals/BUDGET_EXCEEDED and .loki/PAUSE to continue."
                 notify_intervention_needed "Budget limit reached - execution paused" 2>/dev/null || true
+                local pause_result
                 handle_pause
-                local pause_result=$?
+                pause_result=$?
                 rm -f "$loki_dir/PAUSE"
                 if [ "$pause_result" -eq 1 ]; then
                     return 2
@@ -9211,8 +9212,9 @@ check_human_intervention() {
         fi
         log_warn "PAUSE file detected - pausing execution"
         notify_intervention_needed "Execution paused via PAUSE file"
+        local pause_result
         handle_pause
-        local pause_result=$?
+        pause_result=$?
         rm -f "$loki_dir/PAUSE"
         if [ "$pause_result" -eq 1 ]; then
             # STOP was requested during pause
@@ -9228,8 +9230,9 @@ check_human_intervention() {
             rm -f "$loki_dir/PAUSE_AT_CHECKPOINT"
             notify_intervention_needed "Execution paused at checkpoint"
             touch "$loki_dir/PAUSE"
+            local pause_result
             handle_pause
-            local pause_result=$?
+            pause_result=$?
             rm -f "$loki_dir/PAUSE"
             if [ "$pause_result" -eq 1 ]; then
                 return 2


### PR DESCRIPTION
## Summary
- **#56**: Worktree merge JSON parsing -- validates signal file before extracting branch/path, clear error on corruption
- **#58**: Pause signal handling -- properly captures handle_pause return value with separate local declaration
- **#82**: --provider arg parsing -- rejects flags starting with "--" as provider values

## Severity
CRITICAL -- all 3 issues can cause data loss or silent failures

## Test plan
- [ ] `bash -n autonomy/loki` passes
- [ ] `bash -n autonomy/run.sh` passes
- [ ] `loki start prd.md --provider` (no value) shows error
- [ ] Corrupted worktree signal file shows clear error