### PR TITLE
fix: initialize task_json in track_iteration_start

### DIFF
--- a/autonomy/run.sh
+++ b/autonomy/run.sh
@@ -3595,8 +3595,12 @@ except: pass
     prd_escaped=$(printf '%s' "${prd:-Codebase Analysis}" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g')
 
     # Build enriched task JSON with pending task context
-    local task_json
-    if [[ -n "$next_task_context" ]]; then
+    # NOTE: Must initialize to empty string. Under `set -u` (line 152), declaring
+    # `local task_json` without a value leaves it unset, and when the `if` below
+    # is false (e.g. iteration 2+ with empty pending queue), the `-z` check on
+    # line 3626 crashes with "unbound variable".
+    local task_json=""
+    if [[ -n "${next_task_context:-}" ]]; then
         task_json=$(python3 -c "
 import json, sys
 ctx = json.loads('''$next_task_context''')
@@ -3619,11 +3623,11 @@ if ctx.get('source'):
 if ctx.get('project'):
     task['project'] = ctx['project']
 print(json.dumps(task, indent=2))
-" 2>/dev/null)
+" 2>/dev/null) || task_json=""
     fi
 
     # Fallback to basic task JSON if enrichment failed
-    if [[ -z "$task_json" ]]; then
+    if [[ -z "${task_json:-}" ]]; then
         task_json=$(cat <<EOF
 {
   "id": "$task_id",

--- a/tests/test-bugfix-audit.sh
+++ b/tests/test-bugfix-audit.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOKI="$SCRIPT_DIR/../autonomy/loki"
+RUN_SH="$SCRIPT_DIR/../autonomy/run.sh"
 VERSION_FILE="$SCRIPT_DIR/../VERSION"
 
 PASS=0
@@ -81,6 +82,22 @@ test_source_absent() {
         log_fail "$desc" "Pattern should NOT be in source: $pattern"
     else
         log_pass "$desc"
+    fi
+    return 0
+}
+
+# Grep an arbitrary source file for a pattern (for fixes in run.sh etc.)
+test_source_in() {
+    local file="$1"
+    local desc="$2"
+    local pattern="$3"
+
+    ((TOTAL++))
+
+    if grep -qE "$pattern" "$file"; then
+        log_pass "$desc"
+    else
+        log_fail "$desc" "Pattern not found in $(basename "$file"): $pattern"
     fi
     return 0
 }
@@ -350,13 +367,40 @@ test_source "BUG-GH-011: gh status has space before version" \
     'installed \$\(gh --version'
 
 # -------------------------------------------
+# BUG-RUN-003: track_iteration_start crashes with unbound variable
+# Under `set -uo pipefail`, `local task_json` (uninitialized) becomes unset.
+# When the pending queue is empty (e.g. iteration 2+), next_task_context is
+# empty, the enrichment `if` block is skipped, and the subsequent `[[ -z ]]`
+# check on $task_json triggers "unbound variable" and kills the run.
+# Fix: initialize `local task_json=""` and use `${task_json:-}` on read.
+# -------------------------------------------
+test_source_in "$RUN_SH" \
+    "BUG-RUN-003: task_json initialized to empty string in track_iteration_start" \
+    '^[[:space:]]+local task_json=""'
+
+test_source_in "$RUN_SH" \
+    "BUG-RUN-003: task_json fallback read uses defensive guard" \
+    '\[\[ -z "\$\{task_json:-\}" \]\]'
+
+test_source_in "$RUN_SH" \
+    "BUG-RUN-003: next_task_context read uses defensive guard" \
+    '\[\[ -n "\$\{next_task_context:-\}" \]\]'
+
+# -------------------------------------------
 # Syntax validation
 # -------------------------------------------
 ((TOTAL++))
 if bash -n "$LOKI" 2>/dev/null; then
-    log_pass "bash -n syntax validation passes"
+    log_pass "bash -n syntax validation passes (loki)"
 else
-    log_fail "bash -n syntax validation" "script has syntax errors"
+    log_fail "bash -n syntax validation (loki)" "script has syntax errors"
+fi
+
+((TOTAL++))
+if bash -n "$RUN_SH" 2>/dev/null; then
+    log_pass "bash -n syntax validation passes (run.sh)"
+else
+    log_fail "bash -n syntax validation (run.sh)" "script has syntax errors"
 fi
 
 # -------------------------------------------


### PR DESCRIPTION
Under `set -uo pipefail`, `local task_json` without an initializer leaves the variable unset. When the pending queue is empty (iteration 2+ with no tasks left), next_task_context is empty, the enrichment `if` block is skipped, and the subsequent `[[ -z "$task_json" ]]` check crashes with "unbound variable", killing the run.

Initialize `local task_json=""` at declaration and guard reads with `${task_json:-}` and `${next_task_context:-}` for defense in depth. Adds BUG-RUN-003 regression assertions to tests/test-bugfix-audit.sh.

## Description
                                                                                                 
  Fixes a crash in `track_iteration_start` where `local task_json` was
  declared without initialization. Under `set -uo pipefail`, when the                                                   
  pending queue becomes empty (iteration 2+ after all tasks are done),                                                  
  `next_task_context` is empty, the enrichment `if` block is skipped,                                                   
  and the subsequent `[[ -z "$task_json" ]]` check crashes with                                                         
  "unbound variable", killing the run and blocking further iterations.                                                  
                                                                                                                        
  ### Reproduction                                                                                                      
  On v6.75.3 with any PRD:                                                                                              
  1. `loki start prd.md`                                                                                                
  2. First iteration completes                                                                                          
  3. Council votes REJECT (or pending queue otherwise empties)                                                          
  4. Second iteration starts → crash: `task_json: unbound variable`                                                     
                                                                                                                        
  ### Fix                                                                                                               
  - Initialize `local task_json=""` at declaration (autonomy/run.sh:3602)                                               
  - Defensive reads: `${task_json:-}` / `${next_task_context:-}`                                                        
  - Explicit fallback `|| task_json=""` if the python3 heredoc exits non-zero                                           
                                                                                                                        
  ### Audit                                                                                                             
  Scanned run.sh for the same anti-pattern (`local var` without init →                                                  
  conditional `if` assignment → unconditional read). Found 8 candidates;                                                
  all 7 use `if/else` with assignment in both branches (safe) and 1 uses                                                
  `if ! var=$(...)` which assigns inside the condition (safe). `task_json`                                              
  was uniquely vulnerable because it had an `if` without an `else`.     

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Test improvement

## Checklist

- [X] Shell scripts pass syntax validation (`bash -n autonomy/run.sh && bash -n autonomy/loki`)
- [X] All existing tests pass
- [X] New tests added for new functionality (where applicable)
- [X] No emojis in code, comments, documentation, or commit messages
- [X] Version bumped in all required files (if this is a release -- see CLAUDE.md Release Workflow)
- [X] Code follows existing patterns and style conventions

## CLA Acknowledgment

- [X] I have read and agree to the [Contributor License Agreement](CLA.md)

## Related Issues

Closes #
