### PR TITLE
fix: remove single-quoted Python literal from claude stream processor

### DIFF
--- a/autonomy/run.sh
+++ b/autonomy/run.sh
@@ -9740,7 +9740,15 @@ def process_stream():
                         elif tool == "Bash":
                             tool_desc = tool_input.get("description", tool_input.get("command", "")[:60])
                         elif tool == "Grep":
-                            tool_desc = f"pattern: {tool_input.get('pattern', '')}"
+                            # NOTE: This Python block runs as the argument of
+                            # bash `python3 -u -c`, wrapped in a bash single-
+                            # quoted string. Any single-quoted Python literal
+                            # here would close bash SQ mid-code and Python
+                            # would receive `tool_input.get(pattern, )`, a
+                            # bare identifier instead of a string literal,
+                            # crashing with NameError. Use double quotes and
+                            # string concatenation to stay SQ-safe.
+                            tool_desc = "pattern: " + tool_input.get("pattern", "")
                         elif tool == "Glob":
                             tool_desc = tool_input.get("pattern", "")
 

--- a/tests/test-bugfix-audit.sh
+++ b/tests/test-bugfix-audit.sh
@@ -350,13 +350,46 @@ test_source "BUG-GH-011: gh status has space before version" \
     'installed \$\(gh --version'
 
 # -------------------------------------------
+# BUG-RUN-004: Claude stream processor Grep branch used a single-quoted
+# Python literal inside a bash single-quoted heredoc (python3 -u -c '...'),
+# silently breaking bash SQ and making Python see a bare identifier instead
+# of the "pattern" string, crashing with NameError on every Grep tool call.
+# Fix: use double quotes and concatenation, no single-quoted literals in
+# the Python block.
+# -------------------------------------------
+RUN_SH="$SCRIPT_DIR/../autonomy/run.sh"
+
+((TOTAL++))
+if grep -qE 'tool_input\.get\("pattern", ""\)' "$RUN_SH"; then
+    log_pass "BUG-RUN-004: Grep branch reads pattern with double quotes"
+else
+    log_fail "BUG-RUN-004: Grep branch reads pattern with double quotes" \
+        "expected double-quoted .get(\"pattern\", \"\")"
+fi
+
+((TOTAL++))
+if grep -qE "tool_input\.get\('pattern'" "$RUN_SH"; then
+    log_fail "BUG-RUN-004: no single-quoted 'pattern' literal in run.sh" \
+        "single-quoted literal reintroduced -- breaks bash SQ in python3 -u -c"
+else
+    log_pass "BUG-RUN-004: no single-quoted 'pattern' literal in run.sh"
+fi
+
+# -------------------------------------------
 # Syntax validation
 # -------------------------------------------
 ((TOTAL++))
 if bash -n "$LOKI" 2>/dev/null; then
-    log_pass "bash -n syntax validation passes"
+    log_pass "bash -n syntax validation passes (loki)"
 else
-    log_fail "bash -n syntax validation" "script has syntax errors"
+    log_fail "bash -n syntax validation (loki)" "script has syntax errors"
+fi
+
+((TOTAL++))
+if bash -n "$RUN_SH" 2>/dev/null; then
+    log_pass "bash -n syntax validation passes (run.sh)"
+else
+    log_fail "bash -n syntax validation (run.sh)" "script has syntax errors"
 fi
 
 # -------------------------------------------


### PR DESCRIPTION
The claude provider pipes stream-json output through `python3 -u -c '...'` to track tool usage and update the dashboard orchestrator. The Grep branch used `f"pattern: {tool_input.get('pattern', '')}"`, embedding four single quotes inside what is already a bash single-quoted string.

Bash toggles its SQ state on every literal `'`, so the four quotes fall back to SQ-in state (even number of toggles), hiding the problem from bash syntax checks. But each pair also strips its contents out of the SQ, so `'pattern'` becomes a bare word and Python receives `tool_input.get(pattern, )` -- a valid-but-wrong expression that raises `NameError: name "pattern" is not defined` on every Grep call.

The exception aborts the inner `for item in content` loop before `update_orchestrator_task` runs, so Grep invocations were silently missing from `.loki/state/agents.json` and the dashboard tool counter. Claude sessions continued, but every Grep also printed a spurious `[Parse error: name 'pattern' is not defined]` to stderr.

Fix: use double quotes and string concatenation, which stays safe inside bash SQ. Add BUG-RUN-004 regression assertions in tests/test-bugfix-audit.sh to prevent reintroducing the pattern.

 ## Description

  The claude provider pipes stream-json output through `python3 -u -c '...'`                                            
  to track tool usage in the dashboard orchestrator. The Grep branch at
  `autonomy/run.sh:9743` used:                                                                                          
                                                                                                                      
      tool_desc = f"pattern: {tool_input.get('pattern', '')}"                                                           
                                                                                                                      
  embedding four single quotes inside what is already a bash single-quoted                                              
  heredoc. Bash cannot contain a literal `'` inside `'...'` — every `'`                                               
  toggles SQ state. Four toggles leave the shell back in SQ mode (which is                                              
  why `bash -n` sees no syntax error), but each pair strips its contents                                                
  out of the SQ. Python receives:                                                                                       
                                                                                                                        
      tool_desc = f"pattern: {tool_input.get(pattern, )}"                                                               
                                                                                                                        
  a valid-but-wrong expression — `pattern` is now a bare identifier                                                     
  instead of a string literal — and crashes with:
                                                                                                                        
      NameError: name 'pattern' is not defined                                                                        
                                                                                                                        
  The exception is caught at `run.sh:9818` and printed to stderr as                                                     
  `[Parse error: name 'pattern' is not defined]`, which users see
  repeatedly in logs — once per Grep tool call. Because the exception                                                   
  exits the inner `for item in content` loop before                                                                     
  `update_orchestrator_task(tool, tool_desc)` runs, Grep calls are also                                                 
  silently missing from `.loki/state/agents.json` and the dashboard                                                     
  tool counter undercounts.                                                                                             
                                                                                                                        
  ### Reproduction                                                                                                      
  Isolated repro confirming the exact NameError:                                                                        
                                                                                                                        
  ```bash
  python3 -u -c '                                                                                                       
  def f(tool_input):                                                                                                    
      tool_desc = f"pattern: {tool_input.get('pattern', '')}"
      return tool_desc                                                                                                  
  print(f({"pattern": "hello"}))                                                                                      
  '                                                                                                                     
  # NameError: name 'pattern' is not defined                                                                          
  # (python traceback shows: tool_input.get(pattern, ) -- quotes stripped)                                              
                                                                                                                        
  Root cause                                                                                                            
                                                                                                                        
  Introduced in commit f7ea661 ("Fix dashboard to always show orchestrator                                              
  agent"). In the same commit the Glob branch one line below correctly uses
  double quotes (tool_input.get("pattern", "")) — only the Grep branch was                                              
  written with single quotes.                                                                                           
                                                                                                                        
  Unrelated to the historical CHANGELOG.md:5738 entry about                                                             
  name 'pattern' is not defined — that earlier bug was in a different                                                 
  Python heredoc and was fixed by switching to LOKI_CONTEXT env var.                                                    
                                                                                                                        
  Fix                                                                                                                   
                                                                                                                        
  Use double quotes and string concatenation, which is SQ-safe in the bash                                              
  heredoc:
                                                                                                                        
  tool_desc = "pattern: " + tool_input.get("pattern", "")                                                               
  Added an inline comment warning future editors not to introduce single
  quotes inside the python3 -u -c '...' block. The comment itself is                                                    
  carefully written without any single-quote characters.                                                              
                               

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Test improvement

## Checklist

- [X] Shell scripts pass syntax validation (`bash -n autonomy/run.sh && bash -n autonomy/loki`)
- [X] All existing tests pass
- [X] New tests added for new functionality (where applicable)
- [X] No emojis in code, comments, documentation, or commit messages
- [X] Version bumped in all required files (if this is a release -- see CLAUDE.md Release Workflow)
- [X] Code follows existing patterns and style conventions

## CLA Acknowledgment

- [X] I have read and agree to the [Contributor License Agreement](CLA.md)

