### PR TITLE
add MiniMax-M3 to model catalog

### DIFF
--- a/loki-ts/data/model-pricing.json
+++ b/loki-ts/data/model-pricing.json
@@ -8,6 +8,7 @@
     "opus": { "input": 5.0, "output": 25.0 },
     "sonnet": { "input": 3.0, "output": 15.0 },
     "haiku": { "input": 1.0, "output": 5.0 },
-    "gpt-5.3-codex": { "input": 1.75, "output": 14.0 }
+    "gpt-5.3-codex": { "input": 1.75, "output": 14.0 },
+    "MiniMax-M3": { "input": 0.6, "output": 2.4, "cache_input": 0.12 }
   }
 }

--- a/providers/model_catalog.json
+++ b/providers/model_catalog.json
@@ -78,6 +78,39 @@
         { "id": "gpt-4.1", "tier": "development" },
         { "id": "ollama_chat/deepseek-coder", "tier": "fast" }
       ]
+    },
+    "minimax": {
+      "latest_planning": "MiniMax-M3",
+      "latest_development": "MiniMax-M3",
+      "latest_fast": "MiniMax-M3",
+      "openai_base_url": "https://api.minimax.io/v1",
+      "anthropic_base_url": "https://api.minimax.io/anthropic/v1",
+      "endpoints": [
+        {
+          "region": "global_en",
+          "openai_base_url": "https://api.minimax.io/v1",
+          "anthropic_base_url": "https://api.minimax.io/anthropic/v1",
+          "docs_root": "https://platform.minimax.io/docs"
+        },
+        {
+          "region": "cn_zh",
+          "openai_base_url": "https://api.minimaxi.com/v1",
+          "anthropic_base_url": "https://api.minimaxi.com/anthropic/v1",
+          "docs_root": "https://platform.minimaxi.com/docs"
+        }
+      ],
+      "models": [
+        {
+          "id": "MiniMax-M3",
+          "tier": "development",
+          "context_window": 1000000,
+          "input_price_per_mtok": 0.6,
+          "output_price_per_mtok": 2.4,
+          "cache_input_price_per_mtok": 0.12,
+          "thinking": ["adaptive", "disabled"],
+          "notes": "Anthropic-compatible endpoint requires /anthropic/v1. Docs: https://platform.minimax.io/docs/api-reference/api-overview and https://platform.minimaxi.com/docs/api-reference/api-overview."
+        }
+      ]
     }
   }
 }

--- a/providers/model_catalog.json
+++ b/providers/model_catalog.json
@@ -84,18 +84,18 @@
       "latest_development": "MiniMax-M3",
       "latest_fast": "MiniMax-M3",
       "openai_base_url": "https://api.minimax.io/v1",
-      "anthropic_base_url": "https://api.minimax.io/anthropic/v1",
+      "anthropic_base_url": "https://api.minimax.io/anthropic",
       "endpoints": [
         {
           "region": "global_en",
           "openai_base_url": "https://api.minimax.io/v1",
-          "anthropic_base_url": "https://api.minimax.io/anthropic/v1",
+          "anthropic_base_url": "https://api.minimax.io/anthropic",
           "docs_root": "https://platform.minimax.io/docs"
         },
         {
           "region": "cn_zh",
           "openai_base_url": "https://api.minimaxi.com/v1",
-          "anthropic_base_url": "https://api.minimaxi.com/anthropic/v1",
+          "anthropic_base_url": "https://api.minimaxi.com/anthropic",
           "docs_root": "https://platform.minimaxi.com/docs"
         }
       ],
@@ -108,7 +108,7 @@
           "output_price_per_mtok": 2.4,
           "cache_input_price_per_mtok": 0.12,
           "thinking": ["adaptive", "disabled"],
-          "notes": "Anthropic-compatible endpoint requires /anthropic/v1. Docs: https://platform.minimax.io/docs/api-reference/api-overview and https://platform.minimaxi.com/docs/api-reference/api-overview."
+          "notes": "Anthropic-compatible Base URL uses /anthropic. Docs: https://platform.minimax.io/docs/api-reference/api-overview and https://platform.minimaxi.com/docs/api-reference/api-overview."
         }
       ]
     }


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Register MiniMax-M3 in the canonical model catalog with global and China OpenAI/Anthropic-compatible endpoints.
- Add MiniMax-M3 pricing to the model pricing table, including cache input pricing.

## Test plan
- [x] Secret scan with the provided Octopatch regex
- [x] python3 -m json.tool providers/model_catalog.json
- [x] python3 -m json.tool loki-ts/data/model-pricing.json
- [x] bash tests/test-model-and-port.sh
- [ ] bash tests/test-model-override.sh (environment issue: hung after installing dashboard dependencies)

Generated by Octopatch.