### PR TITLE
docs: add OrcaRouter as a gateway covering both routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,14 @@ OpenRouter serves **only** the OpenAI-shaped `/v1/chat/completions`; it has no
 Anthropic `/v1/messages` endpoint. Pointing `ANTHROPIC_BASE_URL` at it does not
 work, which earlier versions of this README incorrectly suggested.
 
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway like
+OpenRouter, so it also works through Route 1 with aider/cline. Unlike OpenRouter
+it additionally serves the Anthropic `/v1/messages` API, so the same key works
+through Route 2 below — one endpoint, both protocols. It also runs
+gateway-level, zero-trust security for AI agents on the same endpoint —
+screening every prompt/response and governing every tool call on a default-deny
+basis, with no application code changes.
+
 *Route 2 -- Anthropic-protocol gateways.* `ANTHROPIC_BASE_URL` routes Claude
 Code itself, so the endpoint must speak the Anthropic Messages API. LiteLLM,
 Bedrock proxies, and self-hosted gateways can:
@@ -455,6 +463,12 @@ loki start prd.md
 export ANTHROPIC_BASE_URL=https://your-gateway.internal/v1
 export ANTHROPIC_API_KEY=...
 export LOKI_MODEL_OVERRIDE=<whatever your gateway calls the model>
+loki start prd.md
+
+# OrcaRouter (same key works for both routes; namespaced model ids required)
+export ANTHROPIC_BASE_URL=https://api.orcarouter.ai
+export ANTHROPIC_API_KEY=sk-orca-...
+export LOKI_MODEL_OVERRIDE=<namespaced id from OrcaRouter's model list, e.g. anthropic/claude-sonnet-5>
 loki start prd.md
 ```
 


### PR DESCRIPTION
## Context

The README's Route 1 example already shows [OpenRouter](https://openrouter.ai) as an OpenAI-compatible gateway for aider/cline, and Route 2 covers Anthropic-protocol gateways via `ANTHROPIC_BASE_URL`. There is one gap: the text right below the OpenRouter block notes that OpenRouter has no Anthropic `/v1/messages` endpoint, so a single key cannot cover both routes.

## What this PR changes

Two small README additions:

1. A paragraph after the OpenRouter warning introducing [OrcaRouter](https://www.orcarouter.ai) as an OpenAI-compatible gateway that **also** serves the Anthropic `/v1/messages` API — so the same key works through Route 1 and Route 2. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
2. A concrete Route 2 example (`ANTHROPIC_BASE_URL=https://api.orcarouter.ai` + namespaced `LOKI_MODEL_OVERRIDE`) in the existing bash block, mirroring the LiteLLM/Ollama examples beside it.

No code changes — documentation only, +14/−0.

## Why OrcaRouter

I verified the claims in the addition before writing them: `https://api.orcarouter.ai/v1/messages` accepts `x-api-key` + `anthropic-version: 2023-06-01` with a namespaced model id (`anthropic/claude-sonnet-5`) and `thinking: { type: "disabled" }`, returning a normal Message with `stop_reason: end_turn`. OrcaRouter requires namespaced model ids, which is why the example uses one.

## Notes

- The OrcaRouter example keeps the existing `loki start prd.md` invocation so it reads like a drop-in for the other examples in the block.
- Existing Ollama/LiteLLM/OpenRouter text is untouched.

I'm an engineer on the OrcaRouter team.
