### PR TITLE
fix(plugin): drop the duplicate hooks declaration from the manifest

### DIFF
--- a/plugins/loki-mode/.claude-plugin/plugin.json
+++ b/plugins/loki-mode/.claude-plugin/plugin.json
@@ -23,6 +23,5 @@
   "commands": [
     "./commands/"
   ],
-  "mcpServers": "./.mcp.json",
-  "hooks": "./hooks/hooks.json"
+  "mcpServers": "./.mcp.json"
 }


### PR DESCRIPTION

Fixes #195.

`plugin.json` declared `"hooks": "./hooks/hooks.json"`. Claude Code already loads that path from the plugin root, and `manifest.hooks` is meant for hook files beyond the standard one, so the loader saw the same file twice and refused the plugin. Every marketplace install landed disabled, and the skills, commands and MCP server went down with it.

Removing the key is the whole change. The hook still comes in through the standard path.

Before:

```
Status: ✘ failed to load
Error: Hook load failed: Duplicate hooks file detected: ./hooks/hooks.json
resolves to already-loaded file .../hooks/hooks.json
```

After:

```
Status: ✔ enabled
```

`claude plugin details loki-mode` still lists the hook, so nothing is lost:

```
Component inventory
  Skills (3)  loki-grill, loki-spec-status, loki-verify
  Hooks (1)  PreToolUse  (harness-only — no model context cost)
  MCP servers (1)  loki-mode
```

Verified on Claude Code 2.1.247 by installing from the marketplace, reproducing the failure, applying the change, and re-checking `plugin list` and `plugin details`.
